### PR TITLE
FIX: OI and Vol reversed from Call/Put

### DIFF
--- a/ttcli/option.py
+++ b/ttcli/option.py
@@ -1028,6 +1028,8 @@ async def chain(
             quote_dict = quote_task.result()
             if show_oi:
                 summary_dict = summary_task.result()  # type: ignore
+            if show_volume:
+                trade_dict = trade_task.result()  # type: ignore
 
     for i, strike in enumerate(all_strikes):
         put_bid = quote_dict[strike.put_streamer_symbol].bid_price
@@ -1049,16 +1051,16 @@ async def chain(
             row.append(f"{put_delta:g}")
 
         if show_theta:
-            prepend.append(f"{abs(greeks_dict[strike.put_streamer_symbol].theta):.2f}")
-            row.append(f"{abs(greeks_dict[strike.call_streamer_symbol].theta):.2f}")
+            prepend.append(f"{abs(greeks_dict[strike.call_streamer_symbol].theta):.2f}")
+            row.append(f"{abs(greeks_dict[strike.put_streamer_symbol].theta):.2f}")
         if show_oi:
             prepend.append(
-                f"{summary_dict[strike.put_streamer_symbol].open_interest}"  # type: ignore
+                f"{summary_dict[strike.call_streamer_symbol].open_interest}"  # type: ignore
             )
-            row.append(f"{summary_dict[strike.call_streamer_symbol].open_interest}")  # type: ignore
+            row.append(f"{summary_dict[strike.put_streamer_symbol].open_interest}")  # type: ignore
         if show_volume:
-            prepend.append(f"{trade_dict[strike.put_streamer_symbol]}")  # type: ignore
-            row.append(f"{trade_dict[strike.call_streamer_symbol]}")  # type: ignore
+            prepend.append(f"{trade_dict[strike.call_streamer_symbol].day_volume}")  # type: ignore
+            row.append(f"{trade_dict[strike.put_streamer_symbol].day_volume}")  # type: ignore
 
         prepend.reverse()
         table.add_row(*(prepend + row), end_section=(i == mid_index - 1))


### PR DESCRIPTION
Running `tt option chain spy --dte 0 --strikes 10 --weeklies` showed the oi in the wrong column and Vol never showed. Note that `~/.config/ttcli/ttcli.cfg` needs to be configure to `show-volume = true`. You can better see how/what happens by using `trade_dict[strike.call_streamer_symbol]`, which places the whole object into the cell so that you can observe the streamer_symbol is the call rather than the put.